### PR TITLE
Do not break the magnet in creative (separately for 1.21.8 if you want to update) 

### DIFF
--- a/src/main/java/net/davdeo/itemmagnetmod/event/custom/PickupItemEvent.java
+++ b/src/main/java/net/davdeo/itemmagnetmod/event/custom/PickupItemEvent.java
@@ -38,7 +38,11 @@ public interface PickupItemEvent {
         }
 
         ItemStack activeMagnet = player.getInventory().getStack(activeMagnetInventoryIndex);
-
+        
+        if (player.getAbilities().creativeMode) {
+            return ActionResult.PASS;
+        }
+        
         ServerPlayerEntity serverPlayer = null;
         if (player instanceof ServerPlayerEntity serverPlayerEntity) {
             serverPlayer = serverPlayerEntity;


### PR DESCRIPTION
If the player is in creative mode, the magnet does not break when it attracts items taken.
UPD: Transferred to #37.
